### PR TITLE
Added "scripts" property to simplify running tests 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Unit tests are written in [Mocha](http://visionmedia.github.io/mocha/). To run t
 
 ```sh
 $ npm install --dev
-$ ./node_modules/mocha/bin/mocha
+$ npm test
 ```
 
 # Credits

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "dependencies": {
     "convert-hex": "~0.1.0",
     "convert-string": "~0.1.0"
+  },
+  "scripts": {
+    "test": "mocha"
   }
 }


### PR DESCRIPTION
without worrying about locating the mocha binary. Simply run tests by issuing `npm test` command.
