### PR TITLE
"browser" in package.json to prevent "crypto" shim

### DIFF
--- a/lib/nodecrypto.js
+++ b/lib/nodecrypto.js
@@ -1,0 +1,36 @@
+var crypto = require('crypto');
+
+// Node.js has its own Crypto function that can handle this natively
+var sha256 = module.exports = function(message, options) {
+	var c = crypto.createHash('sha256');
+	
+	if (Buffer.isBuffer(message)) {
+		c.update(message);
+	} else if (Array.isArray(message)) {
+		// Array of byte values
+		c.update(new Buffer(message));
+	} else {
+		// Otherwise, treat as a binary string
+		c.update(new Buffer(message, 'binary'));
+	}
+	var buf = c.digest();
+	
+	if (options && options.asBytes) {
+		// Array of bytes as decimal integers
+		var a = [];
+		for(var i = 0; i < buf.length; i++) {
+			a.push(buf[i]);
+		}
+		return a;
+	} else if (options && options.asString) {
+		// Binary string
+		return buf.toString('binary');
+	} else {
+		// String of hex characters
+		return buf.toString('hex');
+	}
+}
+
+sha256.x2 = function(message, options) {
+	return sha256(sha256(message, { asBytes:true }), options)
+}

--- a/lib/sha256.js
+++ b/lib/sha256.js
@@ -4,54 +4,13 @@
 var _imports = {}
 
 if (typeof module !== 'undefined' && module.exports) { //CommonJS
-  if (typeof process !== 'undefined' && process.pid) {
-    // Node.js
-	module.exports = sha256_node;
-  } else {
-    _imports.bytesToHex = require('convert-hex').bytesToHex
-    _imports.convertString = require('convert-string')
-    module.exports = sha256
-  }
+  _imports.bytesToHex = require('convert-hex').bytesToHex
+  _imports.convertString = require('convert-string')
+  module.exports = sha256
 } else {
   _imports.bytesToHex = globals.convertHex.bytesToHex
   _imports.convertString = globals.convertString
   globals.sha256 = sha256
-}
-
-
-// Node.js has its own Crypto function that can handle this natively
-function sha256_node(message, options) {
-	var crypto = require('crypto');
-	var c = crypto.createHash('sha256');
-	
-	if (Buffer.isBuffer(message)) {
-		c.update(message);
-	} else if (Array.isArray(message)) {
-		// Array of byte values
-		c.update(new Buffer(message));
-	} else {
-		// Otherwise, treat as a binary string
-		c.update(new Buffer(message, 'binary'));
-	}
-	var buf = c.digest();
-	
-	if (options && options.asBytes) {
-		// Array of bytes as decimal integers
-		var a = [];
-		for(var i = 0; i < buf.length; i++) {
-			a.push(buf[i]);
-		}
-		return a;
-	} else if (options && options.asString) {
-		// Binary string
-		return buf.toString('binary');
-	} else {
-		// String of hex characters
-		return buf.toString('hex');
-	}
-}
-sha256_node.x2 = function(message, options) {
-	return sha256_node(sha256_node(message, { asBytes:true }), options)
 }
 
 /*

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "url": "https://github.com/cryptocoinjs/sha256",
     "type": "git"
   },
-  "main": "./lib/sha256.js",
+  "main": "./lib/nodecrypto.js",
+  "browser": "./lib/sha256.js",
   "dependencies": {
     "convert-hex": "~0.1.0",
     "convert-string": "~0.1.0"

--- a/test/sha256.test.js
+++ b/test/sha256.test.js
@@ -1,50 +1,53 @@
-var sha256 = require('../lib/sha256')
+require('terst');
 
-require('terst')
+['../lib/sha256.js', '../lib/nodecrypto.js'].forEach(function(sha256) {
+  var implementation = sha256.slice(7)
+  sha256 = require(sha256);
 
-describe('+ sha256(input)', function() {
-  describe('> when input is a string', function() {
-    it('should compute the sha256 hash as if it were binary string', function() {
-      var input = "1184CD2CDD640CA42CFC3A091C51D549B2F016D454B2774019C2B2D2E08529FD" // Interpret as binary, not hex
-      EQ (sha256(input), "1c94d91f93ec9ed6bf647c384445b329c84a042c6b3832f8ee904dc55f117342")
+  describe(implementation, function() {
+    describe('+ sha256(input)', function() {
+      describe('> when input is a string', function() {
+        it('should compute the sha256 hash as if it were binary string', function() {
+          var input = "1184CD2CDD640CA42CFC3A091C51D549B2F016D454B2774019C2B2D2E08529FD" // Interpret as binary, not hex
+          EQ (sha256(input), "1c94d91f93ec9ed6bf647c384445b329c84a042c6b3832f8ee904dc55f117342")
 
-      var input = "hello"
-      //printf "hello" | shasum -a 256
-      EQ (sha256(input), "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
-    }),
-	it('should return an array when asked', function() {
-		var test = sha256('hello', { asBytes:true });
-		T (Array.isArray(test));
-		EQ (test.join(','), '44,242,77,186,95,176,163,14,38,232,59,42,197,185,226,158,27,22,30,92,31,167,66,94,115,4,51,98,147,139,152,36');
-	}),
-	it('should return a binary string when asked', function() {
-		var test = sha256('hello', { asString:true });
-		var chars = [44,242,77,186,95,176,163,14,38,232,59,42,197,185,226,158,27,22,30,92,31,167,66,94,115,4,51,98,147,139,152,36];
-		EQ (test, chars.reduce(function(prev, cur, index, arr) {
-			return prev+String.fromCharCode(cur);
-		}, ''));
-	})
+          var input = "hello"
+          //printf "hello" | shasum -a 256
+          EQ (sha256(input), "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
+        }),
+      it('should return an array when asked', function() {
+        var test = sha256('hello', { asBytes:true });
+        T (Array.isArray(test));
+        EQ (test.join(','), '44,242,77,186,95,176,163,14,38,232,59,42,197,185,226,158,27,22,30,92,31,167,66,94,115,4,51,98,147,139,152,36');
+      }),
+      it('should return a binary string when asked', function() {
+        var test = sha256('hello', { asString:true });
+        var chars = [44,242,77,186,95,176,163,14,38,232,59,42,197,185,226,158,27,22,30,92,31,167,66,94,115,4,51,98,147,139,152,36];
+        EQ (test, chars.reduce(function(prev, cur, index, arr) {
+          return prev+String.fromCharCode(cur);
+        }, ''));
+      })
+      })
+    })
+
+    describe('+ x2(input)', function() {
+      describe('> when input is a string', function() {
+        it('should compute the sha256 twice', function() {
+          EQ (sha256.x2("hello"), "9595c9df90075148eb06860365df33584b75bff782a510c6cd4883a419833d50")
+        }),
+      it('should return an array when asked', function() {
+        var test = sha256.x2('hello', { asBytes:true });
+        T (Array.isArray(test));
+        EQ (test.join(','), '149,149,201,223,144,7,81,72,235,6,134,3,101,223,51,88,75,117,191,247,130,165,16,198,205,72,131,164,25,131,61,80');
+      }),
+      it('should return a binary string when asked', function() {
+        var test = sha256.x2('hello', { asString:true });
+        var chars = [149,149,201,223,144,7,81,72,235,6,134,3,101,223,51,88,75,117,191,247,130,165,16,198,205,72,131,164,25,131,61,80];
+        EQ (test, chars.reduce(function(prev, cur, index, arr) {
+          return prev+String.fromCharCode(cur);
+        }, ''));
+      })
+      })
+    })
   })
 })
-
-describe('+ x2(input)', function() {
-  describe('> when input is a string', function() {
-    it('should compute the sha256 twice', function() {
-      EQ (sha256.x2("hello"), "9595c9df90075148eb06860365df33584b75bff782a510c6cd4883a419833d50")
-    }),
-	it('should return an array when asked', function() {
-		var test = sha256.x2('hello', { asBytes:true });
-		T (Array.isArray(test));
-		EQ (test.join(','), '149,149,201,223,144,7,81,72,235,6,134,3,101,223,51,88,75,117,191,247,130,165,16,198,205,72,131,164,25,131,61,80');
-	}),
-	it('should return a binary string when asked', function() {
-		var test = sha256.x2('hello', { asString:true });
-		var chars = [149,149,201,223,144,7,81,72,235,6,134,3,101,223,51,88,75,117,191,247,130,165,16,198,205,72,131,164,25,131,61,80];
-		EQ (test, chars.reduce(function(prev, cur, index, arr) {
-			return prev+String.fromCharCode(cur);
-		}, ''));
-	})
-  })
-})
-
-


### PR DESCRIPTION
[Browserify](https://www.npmjs.com/package/browserify) does static analysis to detect `require` calls and shim Node core appropriately. Even though the module doesn't end up using core `crypto` in the browser as written, Browserify doesn't execute the feature detection code to find this out, and is still packing [a shim](https://www.npmjs.com/package/crypto-browserify). The shim is lots of code for many more algorithms and ciphers in several modules that take time to recursively fetch, analyze, and concatenate.

You can verify this is happening as follows:

```shellscript
npm --global install browserify
browserify --list ./lib/sha256.js | fgrep crypto
```

This PR splits out the wrapper on node core into a separate source file, which is "main" in `package.json` for Node. The other package managers and "browser" in package.json point to `sha256.js`, now lighter by the weight of the wrapper over non-existent Node core.